### PR TITLE
feat: Support url debug and fix wildcard conflicts

### DIFF
--- a/classfile.go
+++ b/classfile.go
@@ -62,6 +62,11 @@ func (p *App) Patch(path string, handle func(ctx *Context)) {
 	p.Route(http.MethodPatch, path, handle)
 }
 
+// Delete is a shortcut for router.Route(http.MethodDelete, path, handle)
+func (p *App) Delete(path string, handle func(ctx *Context)) {
+	p.Route(http.MethodDelete, path, handle)
+}
+
 // Static serves static files from a dir (default is "$YapFS/static").
 func (p *App) Static__0(pattern string, dir ...fs.FS) {
 	p.Static(pattern, dir...)

--- a/demo/classfile_hello/gop_autogen.go
+++ b/demo/classfile_hello/gop_autogen.go
@@ -2,27 +2,44 @@ package main
 
 import "github.com/goplus/yap"
 
-const _ = true
-
 type hello struct {
 	yap.App
 }
 //line demo/classfile_hello/hello_yap.gox:1
 func (this *hello) MainEntry() {
 //line demo/classfile_hello/hello_yap.gox:1:1
-	this.Get("/p/:id", func(ctx *yap.Context) {
+	this.Get("/p/info", func(ctx *yap.Context) {
 //line demo/classfile_hello/hello_yap.gox:2:1
-		ctx.Json__1(map[string]string{"id": ctx.Param("id")})
+		ctx.Json__1(map[string]string{"info": "Test info"})
 	})
 //line demo/classfile_hello/hello_yap.gox:6:1
-	this.Handle("/", func(ctx *yap.Context) {
+	this.Get("/p/:id", func(ctx *yap.Context) {
 //line demo/classfile_hello/hello_yap.gox:7:1
+		ctx.Json__1(map[string]string{"id": ctx.Param("id")})
+	})
+//line demo/classfile_hello/hello_yap.gox:11:1
+	this.Post("/p/:id", func(ctx *yap.Context) {
+//line demo/classfile_hello/hello_yap.gox:12:1
+		ctx.Json__1(map[string]string{"id": ctx.Param("id")})
+	})
+//line demo/classfile_hello/hello_yap.gox:16:1
+	this.Put("/p/:id", func(ctx *yap.Context) {
+//line demo/classfile_hello/hello_yap.gox:17:1
+		ctx.Json__1(map[string]string{"id": ctx.Param("id")})
+	})
+//line demo/classfile_hello/hello_yap.gox:21:1
+	this.Delete("/p/:id", func(ctx *yap.Context) {
+//line demo/classfile_hello/hello_yap.gox:22:1
+		ctx.Json__1(map[string]string{"id": ctx.Param("id")})
+	})
+//line demo/classfile_hello/hello_yap.gox:26:1
+	this.Handle("/", func(ctx *yap.Context) {
+//line demo/classfile_hello/hello_yap.gox:27:1
 		ctx.Html__1(`<html><body>Hello, <a href="/p/123">Yap</a>!</body></html>`)
 	})
-//line demo/classfile_hello/hello_yap.gox:10:1
+//line demo/classfile_hello/hello_yap.gox:30:1
 	this.Run(":8080")
 }
 func main() {
-//line demo/classfile_hello/hello_yap.gox:10:1
 	yap.Gopt_App_Main(new(hello))
 }

--- a/demo/classfile_hello/hello_yap.gox
+++ b/demo/classfile_hello/hello_yap.gox
@@ -1,4 +1,24 @@
+get "/p/info", ctx => {
+	ctx.json {
+		"info": "Test info",
+	}
+}
 get "/p/:id", ctx => {
+	ctx.json {
+		"id": ctx.param("id"),
+	}
+}
+post "/p/:id", ctx => {
+	ctx.json {
+		"id": ctx.param("id"),
+	}	
+}
+put "/p/:id", ctx => {
+	ctx.json {
+		"id": ctx.param("id"),
+	}	
+}
+delete "/p/:id", ctx => {
 	ctx.json {
 		"id": ctx.param("id"),
 	}

--- a/tree.go
+++ b/tree.go
@@ -234,12 +234,13 @@ func (n *node) insertChild(path, fullPath string, handle func(ctx *Context)) {
 			panic("wildcards must be named with a non-empty name in path '" + fullPath + "'")
 		}
 
+		// Allow a wildcard with other named path
 		// Check if this node has existing children which would be
 		// unreachable if we insert the wildcard here
-		if len(n.children) > 0 {
-			panic("wildcard segment '" + wildcard +
-				"' conflicts with existing children in path '" + fullPath + "'")
-		}
+		// if len(n.children) > 0 {
+		// 	panic("wildcard segment '" + wildcard +
+		// 		"' conflicts with existing children in path '" + fullPath + "'")
+		// }
 
 		// param
 		if wildcard[0] == ':' {

--- a/yap.go
+++ b/yap.go
@@ -140,6 +140,9 @@ func (p *Engine) Handler(mws ...func(h http.Handler) http.Handler) http.Handler 
 // Accepted connections are configured to enable TCP keep-alives.
 func (p *Engine) Run(addr string, mws ...func(h http.Handler) http.Handler) error {
 	h := p.Handler(mws...)
+
+	debugPrint("Listening and serving HTTP on %s\n", addr)
+
 	return p.las(addr, h)
 }
 


### PR DESCRIPTION
```bash
classfile_hello % gop run .
[YAP-debug] GET    /p/info                   --> main.(*hello).MainEntry.func1 handlers
[YAP-debug] GET    /p/:id                    --> main.(*hello).MainEntry.func2 handlers
[YAP-debug] POST   /p/:id                    --> main.(*hello).MainEntry.func3 handlers
[YAP-debug] PUT    /p/:id                    --> main.(*hello).MainEntry.func4 handlers
[YAP-debug] DELETE /p/:id                    --> main.(*hello).MainEntry.func5 handlers
[YAP-debug] Listening and serving HTTP on :8080
```